### PR TITLE
feat: PhotoCard 모델에 creatorId 필드 추가 및 생성 제한 로직 수정

### DIFF
--- a/src/prisma/migrations/20250530052646_add_creator_id_to_photo_card/migration.sql
+++ b/src/prisma/migrations/20250530052646_add_creator_id_to_photo_card/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - Added the required column `creatorId` to the `PhotoCard` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "PhotoCard" ADD COLUMN     "creatorId" INTEGER NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "PhotoCard" ADD CONSTRAINT "PhotoCard_creatorId_fkey" FOREIGN KEY ("creatorId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -81,6 +81,7 @@ model User {
   shopListings      Shop[]         @relation("UserShopListings") // 유저가 등록한 판매 게시글 목록 (새로 추가된 관계)
   provider          String         @default("local")
   providerId        String?        @unique
+  PhotoCard         PhotoCard[]
 }
 
 model PhotoCard {
@@ -94,6 +95,8 @@ model PhotoCard {
   initialQuantity Int // PhotoCard 자체의 최초 발행 수량
   createdAt       DateTime   @default(now())
   updatedAt       DateTime   @updatedAt
+  creatorId       Int // 최초 발행자 id
+  creator         User       @relation(fields: [creatorId], references: [id])
   userCard        UserCard[] // 이 종류의 포토카드를 소유한 UserCard 목록
   shopListings    Shop[] // 이 종류의 포토카드가 등록된 판매 게시글 목록
 }

--- a/src/prisma/seed.js
+++ b/src/prisma/seed.js
@@ -62,6 +62,9 @@ async function seed() {
         imageUrl: card.imageUrl,
         price,
         initialQuantity: totalQuantity,
+        creator: {
+          connect: {id: userId},
+        },
       },
     });
 


### PR DESCRIPTION
## 주요 변경사항
- PhotoCard 모델에 creatorId 필드 추가하여 생성자 정보 명시
- 포토카드 월별 생성 제한 로직을 creatorId 기준으로 변경
- 기존 userCard 기준 생성 수 조회 로직 제거

- TODO : 응답 포맷팅 수정